### PR TITLE
fix: Race condition related to modal popup conditions and addition of some QoL changes

### DIFF
--- a/src/components/HomePage/ResultsSection/index.tsx
+++ b/src/components/HomePage/ResultsSection/index.tsx
@@ -9,6 +9,7 @@ interface ResultsSectionProps {
 
 const ResultsSection: FC<ResultsSectionProps> = ({
   medicines,
+  selectedMedicine,
   setSelectedMedicine,
 }) => {
   return (
@@ -20,6 +21,7 @@ const ResultsSection: FC<ResultsSectionProps> = ({
         label="Select Medicine"
         options={medicines.map((medicine) => medicine.matching_name)}
         onChange={setSelectedMedicine}
+        value={selectedMedicine}
         disabled={medicines.length === 0}
       />
     </div>

--- a/src/components/HomePage/SearchSection/index.tsx
+++ b/src/components/HomePage/SearchSection/index.tsx
@@ -34,6 +34,8 @@ const SearchSection: FC<SearchSectionProps> = ({
     }
   };
 
+  const isButtonDisabled = !inputSearch || !sourceLanguage || loading;
+
   return (
     <div className="p-5">
       <div className="m-2 text-lg font-semibold text-center font-inter">
@@ -54,13 +56,13 @@ const SearchSection: FC<SearchSectionProps> = ({
           onChange={(e) => setInputSearch(e.target.value)}
         />
         <button
-          className={`bg-[#2f876e] w-full md:w-1/4 h-12 text-white rounded-lg shadow-md ${
-            loading
-              ? "cursor-not-allowed opacity-50"
-              : "hover:bg-[#256c54] transition-all"
+          className={`w-full md:w-1/4 h-12 rounded-lg shadow-md ${
+            isButtonDisabled
+              ? "bg-gray-400 cursor-not-allowed"
+              : "bg-[#2f876e] text-white hover:bg-[#256c54] transition-all"
           }`}
           onClick={validateAndSearch}
-          disabled={loading}
+          disabled={isButtonDisabled}
         >
           {loading ? "Loading..." : "Search"}
         </button>

--- a/src/components/HomePage/SearchSection/index.tsx
+++ b/src/components/HomePage/SearchSection/index.tsx
@@ -44,6 +44,7 @@ const SearchSection: FC<SearchSectionProps> = ({
           label="Source Language"
           options={languages}
           onChange={setSourceLanguage}
+          value={sourceLanguage}
         />
         <input
           type="text"

--- a/src/components/HomePage/TranslateSection/index.tsx
+++ b/src/components/HomePage/TranslateSection/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC, useState, useEffect } from "react";
 import Dropdown from "@/components/ui/Dropdown";
 import SectionError from "@/components/HomePage/SectionError";
 import LastResortWarnModal from "@/components/ui/modals/LastResortWarnModal";
@@ -30,6 +30,11 @@ const TranslateSection: FC<TranslateSectionProps> = ({
   const [isWarningModalOpen, setIsWarningModalOpen] = useState<boolean>(false);
   const [lastResortResult, setLastResortResult] = useState<string>("");
   const [lastResortLoading, setLastResortLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    setLastResortResult("");
+    setIsWarningModalOpen(false);
+  }, [selectedMedicine]);
 
   const validateAndTranslate = async () => {
     if (!targetLanguage) {

--- a/src/components/HomePage/TranslateSection/index.tsx
+++ b/src/components/HomePage/TranslateSection/index.tsx
@@ -65,6 +65,9 @@ const TranslateSection: FC<TranslateSectionProps> = ({
     }
   };
 
+  const isButtonDisabled =
+    !targetLanguage || !selectedMedicine || loading || lastResortLoading;
+
   return (
     <div className="p-5">
       <div className="m-2 text-lg font-semibold text-center font-inter">
@@ -80,13 +83,13 @@ const TranslateSection: FC<TranslateSectionProps> = ({
         />
         <div className="flex flex-col w-full md:w-1/4">
           <button
-            className={`bg-[#2f876e] h-12 text-white rounded-lg shadow-md ${
-              loading || lastResortLoading
-                ? "cursor-not-allowed opacity-50"
-                : "hover:bg-[#256c54] transition-all"
+            className={`h-12 rounded-lg shadow-md ${
+              isButtonDisabled
+                ? "bg-gray-400 cursor-not-allowed"
+                : "bg-[#2f876e] text-white hover:bg-[#256c54] transition-all"
             }`}
             onClick={validateAndTranslate}
-            disabled={loading || lastResortLoading || !selectedMedicine}
+            disabled={isButtonDisabled}
           >
             {loading
               ? "Loading..."

--- a/src/components/HomePage/TranslateSection/index.tsx
+++ b/src/components/HomePage/TranslateSection/index.tsx
@@ -70,6 +70,7 @@ const TranslateSection: FC<TranslateSectionProps> = ({
           label="Target Language"
           options={languages}
           onChange={setTargetLanguage}
+          value={targetLanguage}
           disabled={!selectedMedicine}
         />
         <div className="flex flex-col w-full md:w-1/4">

--- a/src/components/HomePage/TranslateSection/index.tsx
+++ b/src/components/HomePage/TranslateSection/index.tsx
@@ -9,7 +9,7 @@ interface TranslateSectionProps {
   targetLanguage: string;
   setTargetLanguage: (value: string) => void;
   outputTranslation: string;
-  handleTranslate: () => Promise<void>;
+  handleTranslate: () => Promise<string | null>;
   languages: string[];
   translateError: string | null;
   setTranslateError: (msg: string | null) => void;
@@ -36,8 +36,8 @@ const TranslateSection: FC<TranslateSectionProps> = ({
       setTranslateError("Target language is required.");
     } else {
       setTranslateError(null);
-      await handleTranslate();
-      if (!outputTranslation) {
+      const translation = await handleTranslate();
+      if (!translation) {
         setIsWarningModalOpen(true);
       }
     }

--- a/src/components/HomePage/TranslateSection/index.tsx
+++ b/src/components/HomePage/TranslateSection/index.tsx
@@ -9,6 +9,7 @@ interface TranslateSectionProps {
   targetLanguage: string;
   setTargetLanguage: (value: string) => void;
   outputTranslation: string;
+  setOutputTranslation: (value: string) => void;
   handleTranslate: () => Promise<string | null>;
   languages: string[];
   translateError: string | null;
@@ -21,6 +22,7 @@ const TranslateSection: FC<TranslateSectionProps> = ({
   targetLanguage,
   setTargetLanguage,
   outputTranslation,
+  setOutputTranslation,
   handleTranslate,
   languages,
   translateError,
@@ -28,11 +30,9 @@ const TranslateSection: FC<TranslateSectionProps> = ({
   loading,
 }) => {
   const [isWarningModalOpen, setIsWarningModalOpen] = useState<boolean>(false);
-  const [lastResortResult, setLastResortResult] = useState<string>("");
   const [lastResortLoading, setLastResortLoading] = useState<boolean>(false);
 
   useEffect(() => {
-    setLastResortResult("");
     setIsWarningModalOpen(false);
   }, [selectedMedicine]);
 
@@ -41,6 +41,7 @@ const TranslateSection: FC<TranslateSectionProps> = ({
       setTranslateError("Target language is required.");
     } else {
       setTranslateError(null);
+      setOutputTranslation("");
       const translation = await handleTranslate();
       if (!translation) {
         setIsWarningModalOpen(true);
@@ -51,13 +52,14 @@ const TranslateSection: FC<TranslateSectionProps> = ({
   const handleConfirmEnable = async () => {
     setIsWarningModalOpen(false);
     setLastResortLoading(true);
+    setOutputTranslation("");
     try {
       const translated = await handleLastResort(
         selectedMedicine,
         targetLanguage,
         process.env.NEXT_PUBLIC_API_URL,
       );
-      setLastResortResult(translated);
+      setOutputTranslation(translated);
     } catch {
       setTranslateError("Last resort translation failed.");
     } finally {
@@ -106,7 +108,7 @@ const TranslateSection: FC<TranslateSectionProps> = ({
           type="text"
           className="w-full h-12 text-base text-center font-inter font-semibold text-[#044677] shadow-md border border-gray-300 rounded-md md:w-1/2 focus:border-[#2f876e] focus:ring-[#2f876e] focus:outline-none p-2"
           placeholder="Translation will appear here"
-          value={outputTranslation || lastResortResult}
+          value={outputTranslation}
           readOnly
         />
       </div>

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC } from "react";
 import {
   FormControl,
   InputLabel,
@@ -12,6 +12,7 @@ interface DropdownProps {
   label: string;
   options: string[];
   onChange: (value: string) => void;
+  value: string;
   disabled?: boolean;
 }
 
@@ -19,21 +20,19 @@ const Dropdown: FC<DropdownProps> = ({
   label,
   options,
   onChange,
+  value,
   disabled = false,
 }) => {
-  const [selectedOption, setSelectedOption] = useState<string>("");
-
   const handleChange = (event: SelectChangeEvent<string>): void => {
-    const value = event.target.value;
-    setSelectedOption(value);
-    onChange(value);
+    const selectedValue = event.target.value;
+    onChange(selectedValue);
   };
 
   return (
     <FormControl fullWidth disabled={disabled}>
       <InputLabel>{label}</InputLabel>
       <Select
-        value={selectedOption}
+        value={value}
         onChange={handleChange}
         input={<OutlinedInput label={label} />}
       >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,6 +49,8 @@ const HomePage: FC = () => {
     setLoadingTranslate(false);
   };
 
+  const targetLanguages = languages.filter((lang) => lang !== sourceLanguage);
+
   return (
     <div className="relative flex flex-col overflow-hidden">
       <Head>
@@ -98,7 +100,7 @@ const HomePage: FC = () => {
           setTargetLanguage={setTargetLanguage}
           outputTranslation={outputTranslation}
           handleTranslate={handleTranslateAction}
-          languages={languages}
+          languages={targetLanguages}
           translateError={translateError}
           setTranslateError={setTranslateError}
           loading={loadingTranslate}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,6 +49,12 @@ const HomePage: FC = () => {
     setLoadingTranslate(false);
   };
 
+  const handleSetSourceLanguage = (lang: string) => {
+    setSourceLanguage(lang);
+    setSelectedMedicine("");
+    setOutputTranslation("");
+  };
+
   const targetLanguages = languages.filter((lang) => lang !== sourceLanguage);
 
   return (
@@ -80,7 +86,7 @@ const HomePage: FC = () => {
           inputSearch={inputSearch}
           setInputSearch={setInputSearch}
           sourceLanguage={sourceLanguage}
-          setSourceLanguage={setSourceLanguage}
+          setSourceLanguage={handleSetSourceLanguage}
           handleSearch={handleSearchAction}
           languages={languages}
           searchError={searchError}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -70,6 +70,10 @@ const HomePage: FC = () => {
     setTranslateError(null);
   }, [selectedMedicine]);
 
+  useEffect(() => {
+    setOutputTranslation("");
+  }, [targetLanguage]);
+
   return (
     <div className="relative flex flex-col overflow-hidden">
       <Head>
@@ -119,6 +123,7 @@ const HomePage: FC = () => {
           setTargetLanguage={setTargetLanguage}
           outputTranslation={outputTranslation}
           handleTranslate={handleTranslateAction}
+          setOutputTranslation={setOutputTranslation}
           languages={targetLanguages}
           translateError={translateError}
           setTranslateError={setTranslateError}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,15 +38,22 @@ const HomePage: FC = () => {
     setLoadingSearch(false);
   };
 
-  const handleTranslateAction = async () => {
+  const handleTranslateAction = async (): Promise<string | null> => {
     setLoadingTranslate(true);
-    await handleTranslate(
-      selectedMedicine,
-      targetLanguage,
-      setOutputTranslation,
-      NEXT_PUBLIC_API_URL,
-    );
-    setLoadingTranslate(false);
+    try {
+      const translation = await handleTranslate(
+        selectedMedicine,
+        targetLanguage,
+        setOutputTranslation,
+        NEXT_PUBLIC_API_URL,
+      );
+      return translation;
+    } catch {
+      setTranslateError("Translation failed.");
+      return null;
+    } finally {
+      setLoadingTranslate(false);
+    }
   };
 
   const handleSetSourceLanguage = (lang: string) => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,7 @@ import Head from "next/head";
 
 const NEXT_PUBLIC_API_URL: string | undefined = process.env.NEXT_PUBLIC_API_URL;
 
-const languages = ["English", "Ukrainian", "Russian", "German"];
+const languages = ["English", "Ukrainian", "Russian", "French"];
 
 const HomePage: FC = () => {
   const [inputSearch, setInputSearch] = useState<string>("");

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FC } from "react";
+import React, { useState, useEffect, FC } from "react";
 import SearchSection from "@/components/HomePage/SearchSection";
 import ResultsSection from "@/components/HomePage/ResultsSection";
 import TranslateSection from "@/components/HomePage/TranslateSection";
@@ -63,6 +63,12 @@ const HomePage: FC = () => {
   };
 
   const targetLanguages = languages.filter((lang) => lang !== sourceLanguage);
+
+  useEffect(() => {
+    setTargetLanguage("");
+    setOutputTranslation("");
+    setTranslateError(null);
+  }, [selectedMedicine]);
 
   return (
     <div className="relative flex flex-col overflow-hidden">

--- a/src/utils/__tests__/handleLastResort.test.ts
+++ b/src/utils/__tests__/handleLastResort.test.ts
@@ -1,0 +1,83 @@
+// Author: Matthew Quijano
+
+// Notes:
+// import { expect } from "@jest/globals"; to avoid type conflicts with Cypress.
+// Tests for handling cases where NEXT_PUBLIC_API_URL is missing, API response is successful, or throws an error.
+
+// Test cases:
+// 1. It should fetch translation and return translated medicine with a successful API response.
+// 2. It should throw an error when NEXT_PUBLIC_API_URL is undefined.
+// 3. It should throw an error when the API response status is not ok (200).
+// 4. It should throw an error if there is no translated medicine in the response.
+
+import { expect } from "@jest/globals";
+import handleLastResort from "../handleLastResort";
+import fetchMock from "jest-fetch-mock";
+
+fetchMock.enableMocks();
+
+describe("handleLastResort", () => {
+  const NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  it("fetches translation and returns translated medicine with a successful API response", async () => {
+    const mockData = { translated_medicine: "Тиленол" };
+    fetchMock.mockResponseOnce(JSON.stringify(mockData));
+
+    const result = await handleLastResort(
+      "Tylenol",
+      "Ukrainian",
+      NEXT_PUBLIC_API_URL,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${NEXT_PUBLIC_API_URL}/last-resort/`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          medicine: "Tylenol",
+          target_language: "Ukrainian",
+        }),
+      },
+    );
+    expect(result).toBe("Тиленол");
+  });
+
+  it("throws an error when NEXT_PUBLIC_API_URL is undefined", async () => {
+    await expect(
+      handleLastResort("Tylenol", "Ukrainian", undefined),
+    ).rejects.toThrow("Backend URL is undefined");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws an error when the API response status is not ok (200)", async () => {
+    fetchMock.mockResponseOnce("Service Unavailable", { status: 503 });
+
+    await expect(
+      handleLastResort("Tylenol", "Ukrainian", NEXT_PUBLIC_API_URL),
+    ).rejects.toThrow(
+      "Last Resort HTTP error! Status: 503, Message: Service Unavailable",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws an error if there is no translated medicine in the response", async () => {
+    const mockData = {};
+    fetchMock.mockResponseOnce(JSON.stringify(mockData));
+
+    await expect(
+      handleLastResort("Tylenol", "Ukrainian", NEXT_PUBLIC_API_URL),
+    ).rejects.toThrow("No translation results available from last resort.");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/__tests__/handleTranslate.test.ts
+++ b/src/utils/__tests__/handleTranslate.test.ts
@@ -1,0 +1,142 @@
+// Author: Matthew Quijano
+
+// Notes:
+// import { expect } from "@jest/globals"; to avoid type conflicts with Cypress.
+// Validates target language against languageMapping before sending the request to API.
+
+// Test cases:
+// 1. It should fetch translation and update state with successful API response.
+// 2. It should throw an error when the API request fails.
+// 3. It should throw an error when the API response status is not ok (200).
+// 4. It should throw an error if the target language is invalid.
+// 5. It should throw an error if there are no translation results available.
+// 6. It should handle cases where results is undefined in the API response.
+
+import { expect } from "@jest/globals";
+import handleTranslate from "../handleTranslate";
+import fetchMock from "jest-fetch-mock";
+
+fetchMock.enableMocks();
+
+describe("handleTranslate", () => {
+  let setOutputTranslation: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    setOutputTranslation = jest.fn();
+  });
+
+  it("fetches translation and updates state with successful API response", async () => {
+    const mockData = { results: [{ translated_name: "Тиленол" }] };
+    fetchMock.mockResponseOnce(JSON.stringify(mockData));
+
+    const NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+    await handleTranslate(
+      "Tylenol",
+      "Ukrainian",
+      setOutputTranslation,
+      NEXT_PUBLIC_API_URL,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${NEXT_PUBLIC_API_URL}/translate/`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          translation_query: {
+            matching_name: "Tylenol",
+            matching_source: "example_source",
+            matching_uid: 1,
+          },
+          target_language: "uk",
+        }),
+      },
+    );
+    expect(setOutputTranslation).toHaveBeenCalledWith("Тиленол");
+  });
+
+  it("throws an error when the API request fails", async () => {
+    fetchMock.mockRejectOnce(new Error("Fetch failed"));
+
+    const NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+    const result = await handleTranslate(
+      "Tylenol",
+      "Ukrainian",
+      setOutputTranslation,
+      NEXT_PUBLIC_API_URL,
+    );
+
+    expect(result).toBeNull();
+    expect(setOutputTranslation).not.toHaveBeenCalled();
+  });
+
+  it("throws an error when the API response status is not ok (200)", async () => {
+    fetchMock.mockResponseOnce("", { status: 404 });
+
+    const NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+    const result = await handleTranslate(
+      "Tylenol",
+      "Ukrainian",
+      setOutputTranslation,
+      NEXT_PUBLIC_API_URL,
+    );
+
+    expect(result).toBeNull();
+    expect(setOutputTranslation).not.toHaveBeenCalled();
+  });
+
+  it("throws an error if the target language is invalid", async () => {
+    const NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+    const result = await handleTranslate(
+      "Tylenol",
+      "InvalidLanguage",
+      setOutputTranslation,
+      NEXT_PUBLIC_API_URL,
+    );
+
+    expect(result).toBeNull();
+    expect(setOutputTranslation).not.toHaveBeenCalled();
+  });
+
+  it("throws an error if there are no translation results available", async () => {
+    const mockData = { results: [] }; // Simulating no translation results
+    fetchMock.mockResponseOnce(JSON.stringify(mockData));
+
+    const NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+    const result = await handleTranslate(
+      "Tylenol",
+      "Ukrainian",
+      setOutputTranslation,
+      NEXT_PUBLIC_API_URL,
+    );
+
+    expect(result).toBeNull();
+    expect(setOutputTranslation).not.toHaveBeenCalled();
+  });
+
+  it("handles cases where results is undefined in the API response", async () => {
+    const mockData = {};
+    fetchMock.mockResponseOnce(JSON.stringify(mockData));
+
+    const NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+    const result = await handleTranslate(
+      "Tylenol",
+      "Ukrainian",
+      setOutputTranslation,
+      NEXT_PUBLIC_API_URL,
+    );
+
+    expect(result).toBeNull();
+    expect(setOutputTranslation).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/handleTranslate/index.ts
+++ b/src/utils/handleTranslate/index.ts
@@ -9,7 +9,7 @@ const handleTranslate = async (
       English: "en",
       Ukrainian: "uk",
       Russian: "ru",
-      Greek: "gr",
+      French: "fr",
     };
     const targetLanguageCode = languageMapping[targetLanguage];
     if (!targetLanguageCode) {

--- a/src/utils/handleTranslate/index.ts
+++ b/src/utils/handleTranslate/index.ts
@@ -3,7 +3,7 @@ const handleTranslate = async (
   targetLanguage: string,
   setOutputTranslation: (translation: string) => void,
   NEXT_PUBLIC_API_URL: string | undefined,
-): Promise<void> => {
+): Promise<string | null> => {
   try {
     const languageMapping: { [key: string]: string } = {
       English: "en",
@@ -41,11 +41,13 @@ const handleTranslate = async (
     const firstResult = dataFromServer.results?.[0];
     if (firstResult) {
       setOutputTranslation(firstResult.translated_name);
+      return firstResult.translated_name;
     } else {
       throw new Error("No translation results available.");
     }
   } catch (error) {
     console.error("Error in handleTranslate function:", error);
+    return null;
   }
 };
 


### PR DESCRIPTION
- State of output translation wouldn't update in time before the modal state was considered. This would result in the modal appearing before the translation API could fully return results. To alleviate this, I return the translation result more explicitly from inside the handleTranslate function only after the API completes.
- Form fields clear based on various user interactions.
  - Selecting different source language
  - Selecting different medicine
